### PR TITLE
Link opflex agent with Static boost.

### DIFF
--- a/agent-ovs/Makefile.am
+++ b/agent-ovs/Makefile.am
@@ -12,6 +12,28 @@
 
 ACLOCAL_AMFLAGS = -I m4
 
+if HAVE_STATIC_BOOST
+$(info Static boost enabled)
+$(info BOOST_STATIC_LIB_DIR $(BOOST_STATIC_LIB_DIR))
+USE_BOOST_SYSTEM_LIB=$(BOOST_STATIC_LIB_DIR)/libboost_system.a
+USE_BOOST_FILESYSTEM_LIB=$(BOOST_STATIC_LIB_DIR)/libboost_filesystem.a
+USE_BOOST_PROGRAM_OPTIONS_LIB=$(BOOST_STATIC_LIB_DIR)/libboost_program_options.a
+USE_BOOST_UNIT_TEST_FRAMEWORK_LIB=$(BOOST_STATIC_LIB_DIR)/libboost_test_exec_monitor.a \
+				  $(BOOST_STATIC_LIB_DIR)/libboost_unit_test_framework.a
+USE_BOOST_IOSTREAMS_LIB=$(BOOST_STATIC_LIB_DIR)/libboost_iostreams.a
+USE_TEST_FLAGS=-DBoost_USE_STATIC_LIBS=ON
+RPM_BUILD_FLAGS=--without-dynboost
+else
+$(info Static boost disabled)
+USE_BOOST_SYSTEM_LIB=$(BOOST_SYSTEM_LIB)
+USE_BOOST_FILESYSTEM_LIB=$(BOOST_FILESYSTEM_LIB)
+USE_BOOST_ASIO_LIB=$(BOOST_ASIO_LIB)
+USE_BOOST_PROGRAM_OPTIONS_LIB=$(BOOST_PROGRAM_OPTIONS_LIB)
+USE_BOOST_UNIT_TEST_FRAMEWORK_LIB=$(BOOST_UNIT_TEST_FRAMEWORK_LIB)
+USE_BOOST_IOSTREAMS_LIB=$(BOOST_IOSTREAMS_LIB)
+USE_TEST_FLAGS=-DBOOST_TEST_DYN_LINK
+endif
+
 OVS_ADDL_CFLAGS = \
 	-D__STDC_LIMIT_MACROS \
 	-D__STDC_CONSTANT_MACROS \
@@ -36,9 +58,9 @@ libopflex_agent_la_LIBADD = \
 	$(libopflex_LIBS) \
 	$(libmodelgbp_LIBS) \
 	$(libnfct_LIBS) \
-	$(BOOST_SYSTEM_LIB) \
-	$(BOOST_FILESYSTEM_LIB) \
-	$(BOOST_ASIO_LIB)
+	$(USE_BOOST_SYSTEM_LIB) \
+	$(USE_BOOST_FILESYSTEM_LIB) \
+	$(USE_BOOST_ASIO_LIB)
 
 libopflex_agent_la_includedir = $(includedir)/opflexagent
 libopflex_agent_la_include_HEADERS = \
@@ -188,9 +210,9 @@ if RENDERER_OVS
 	$(libmodelgbp_LIBS) \
 	$(libopenvswitch_LIBS) \
 	$(libofproto_LIBS) \
-	$(BOOST_SYSTEM_LIB) \
-	$(BOOST_FILESYSTEM_LIB) \
-	$(BOOST_ASIO_LIB)
+	$(USE_BOOST_SYSTEM_LIB) \
+	$(USE_BOOST_FILESYSTEM_LIB) \
+	$(USE_BOOST_ASIO_LIB)
   libopflex_agent_renderer_openvswitch_la_LIBADD = \
 	librenderer_openvswitch.la
   libopflex_agent_renderer_openvswitch_la_LDFLAGS = \
@@ -205,9 +227,9 @@ opflex_agent_SOURCES = \
 	cmd/opflex_agent.cpp
 opflex_agent_LDADD = \
 	$(libopflex_LIBS) \
-	$(BOOST_PROGRAM_OPTIONS_LIB) \
-	$(BOOST_FILESYSTEM_LIB) \
-	$(BOOST_SYSTEM_LIB) \
+	$(USE_BOOST_PROGRAM_OPTIONS_LIB) \
+	$(USE_BOOST_FILESYSTEM_LIB) \
+	$(USE_BOOST_SYSTEM_LIB) \
 	libopflex_agent.la
 
 gbp_inspect_CXXFLAGS = -DSYSCONFDIR='"$(sysconfdir)"'
@@ -216,17 +238,17 @@ gbp_inspect_SOURCES = \
 gbp_inspect_LDADD = \
 	$(libopflex_LIBS) \
 	$(libmodelgbp_LIBS) \
-	$(BOOST_IOSTREAMS_LIB) \
-	$(BOOST_PROGRAM_OPTIONS_LIB) \
+        $(USE_BOOST_IOSTREAMS_LIB) \
+        $(USE_BOOST_PROGRAM_OPTIONS_LIB) \
 	libopflex_agent.la
 
 mcast_daemon_CXXFLAGS = -DLOCALSTATEDIR='"$(localstatedir)"'
 mcast_daemon_SOURCES = \
 	cmd/mcast_daemon.cpp
 mcast_daemon_LDADD = \
-	$(BOOST_FILESYSTEM_LIB) \
-	$(BOOST_SYSTEM_LIB) \
-	$(BOOST_PROGRAM_OPTIONS_LIB) \
+        $(USE_BOOST_FILESYSTEM_LIB) \
+        $(USE_BOOST_SYSTEM_LIB) \
+        $(USE_BOOST_PROGRAM_OPTIONS_LIB) \
 	libopflex_agent.la
 
 TESTS = agent_test
@@ -237,7 +259,7 @@ agent_test_CXXFLAGS = \
 	-I$(top_srcdir)/lib/include \
 	-I$(top_srcdir)/cmd/test/include \
 	$(libopflex_CFLAGS) $(libmodelgbp_CFLAGS) \
-	-DBOOST_TEST_DYN_LINK
+	$(USE_TEST_FLAGS)
 
 agent_test_includedir = $(includedir)/opflexagent/test
 agent_test_include_HEADERS = \
@@ -258,9 +280,9 @@ agent_test_SOURCES = \
 agent_test_LDADD = \
 	$(libopflex_LIBS) \
 	$(libmodelgbp_LIBS) \
-	$(BOOST_FILESYSTEM_LIB) \
-	$(BOOST_SYSTEM_LIB) \
-	$(BOOST_UNIT_TEST_FRAMEWORK_LIB) \
+	$(USE_BOOST_FILESYSTEM_LIB) \
+	$(USE_BOOST_SYSTEM_LIB) \
+	$(USE_BOOST_UNIT_TEST_FRAMEWORK_LIB) \
 	libopflex_agent.la
 
 if RENDERER_OVS
@@ -306,7 +328,7 @@ mock_server_SOURCES = \
 mock_server_LDADD = \
 	$(libopflex_LIBS) \
 	$(libmodelgbp_LIBS) \
-	$(BOOST_PROGRAM_OPTIONS_LIB) \
+        $(USE_BOOST_PROGRAM_OPTIONS_LIB) \
 	libopflex_agent.la
 
 policy_repo_stress_CXXFLAGS = \
@@ -316,9 +338,9 @@ policy_repo_stress_SOURCES = \
 	cmd/test/policy_repo_stress.cpp
 policy_repo_stress_LDADD = \
 	$(libopflex_LIBS) \
-	$(BOOST_PROGRAM_OPTIONS_LIB) \
-	$(BOOST_FILESYSTEM_LIB) \
-	$(BOOST_SYSTEM_LIB) \
+	$(USE_BOOST_PROGRAM_OPTIONS_LIB) \
+	$(USE_BOOST_FILESYSTEM_LIB) \
+	$(USE_BOOST_SYSTEM_LIB) \
 	libopflex_agent.la
 
 agentconfdir=$(sysconfdir)/opflex-agent-ovs
@@ -354,7 +376,7 @@ if HAVE_DOXYGEN
 endif
 
 integration_test_CXXFLAGS = \
-	$(BOOST_CPPFLAGS) -DBOOST_TEST_DYN_LINK \
+	$(BOOST_CPPFLAGS) $(USE_TEST_FLAGS) \
 	-I$(top_srcdir)/integration-test/include
 
 integration_test_SOURCES = \
@@ -363,8 +385,8 @@ integration_test_SOURCES = \
 
 integration_test_LDFLAGS = $(BOOST_LDFLAGS)
 integration_test_LDADD = \
-	$(BOOST_SYSTEM_LIB) \
-	$(BOOST_UNIT_TEST_FRAMEWORK_LIB) \
+	$(USE_BOOST_SYSTEM_LIB) \
+	$(USE_BOOST_UNIT_TEST_FRAMEWORK_LIB) \
 	libopflex_agent.la
 
 if RENDERER_OVS
@@ -407,14 +429,14 @@ RPMDIRS=rpm/BUILD rpm/SOURCES rpm/RPMS rpm/SRPMS
 rpm: dist rpm/${PACKAGE}.spec
 	mkdir -p ${RPMDIRS}
 	cp ${SOURCE_FILE} rpm/SOURCES/
-	rpmbuild ${RPMFLAGS} -ba rpm/${PACKAGE}.spec
+	rpmbuild ${RPMFLAGS} ${RPM_BUILD_FLAGS} -ba rpm/${PACKAGE}.spec
 	cp rpm/RPMS/${ARCH}/*.rpm .
 	cp rpm/SRPMS/*.rpm .
 	rm -rf ${RPMDIRS}
 srpm: dist rpm/${PACKAGE}.spec
 	mkdir -p ${RPMDIRS}
 	cp ${SOURCE_FILE} rpm/SOURCES/
-	rpmbuild ${RPMFLAGS} -bs rpm/${PACKAGE}.spec
+	rpmbuild ${RPMFLAGS} ${RPM_BUILD_FLAGS} -bs rpm/${PACKAGE}.spec
 	cp rpm/SRPMS/*.rpm .
 	rm -rf ${RPMDIRS}
 

--- a/agent-ovs/configure.ac
+++ b/agent-ovs/configure.ac
@@ -93,6 +93,27 @@ AM_COND_IF([RENDERER_OVS],
            [AC_MSG_NOTICE([Open vSwitch renderer is enabled])],
            [AC_MSG_NOTICE([Open vSwitch renderer is disabled])])
 
+# --with-static-boost enables linking with a static boost library
+# Disabled by default
+# --with-static-boost also requires --with-boost that points to
+# boost location with boost static libraries compiled with -fPIC
+# option to enable linking them with shared libraries.
+AC_ARG_WITH([static-boost],
+            [AS_HELP_STRING([--with-static-boost],[Enable static boost support])],
+            [],[with_static_boost=no])
+AS_IF([test "x$with_static_boost" != xno], [
+      AC_ARG_WITH([boost],
+                  [AS_HELP_STRING([--with-boost],[Use boost from location])],
+                  [], [AC_MSG_FAILURE([--with-static-boost given, but --with-boost is missing])])
+])
+AM_CONDITIONAL([HAVE_STATIC_BOOST],[test "x$with_static_boost" != 'xno'])
+if test "x$with_static_boost" != xno; then
+   AC_SUBST(BOOST_STATIC_LIB_DIR, [${with_boost}/lib])
+   AC_MSG_NOTICE([Building with Static boost libraries from $with_boost/lib])
+else
+   AC_MSG_NOTICE([Building without Static boost libraries])
+fi
+
 # ---------------------------------------------------------------
 # Dependency checks
 

--- a/agent-ovs/lib/LearningBridgeManager.cpp
+++ b/agent-ovs/lib/LearningBridgeManager.cpp
@@ -343,6 +343,7 @@ getVlanRangesByIface(const std::string& uuid,
     auto it = lbi_map.find(uuid);
     if (it == lbi_map.end()) return;
 
+    LOG(DEBUG) << "getVlanRangesByIface for " << uuid;
     for (auto r : it->second.iface->getTrunkVlans()) {
         auto it = range_lbi_map.find(r);
 
@@ -351,6 +352,7 @@ getVlanRangesByIface(const std::string& uuid,
                 break;
 
             ranges.insert(it->first);
+            it++;
         }
     }
 }

--- a/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
+++ b/agent-ovs/lib/include/opflexagent/test/ModbFixture.h
@@ -99,7 +99,6 @@ public:
     std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier7;
     std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier8;
     std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier9;
-    std::shared_ptr<modelgbp::gbpe::L24Classifier> classifier10;
 
     std::shared_ptr<modelgbp::gbp::AllowDenyAction> action1;
 
@@ -338,10 +337,6 @@ protected:
             .setEtherT(l2::EtherTypeEnumT::CONST_IPV4).setProt(6 /* TCP */)
             .setSFromPort(66).setSToPort(69)
             .setDFromPort(94).setDToPort(95);
-        classifier10 = space->addGbpeL24Classifier("classifier10");
-        classifier10->setOrder(30)
-            .setEtherT(l2::EtherTypeEnumT::CONST_IPV4).setProt(1 /* ICMP */)
-            .setIcmpType(10).setIcmpCode(5);
         con3 = space->addGbpContract("contract3");
         con3->addGbpSubject("3_subject1")->addGbpRule("3_1_rule1")
             ->setOrder(1)
@@ -356,11 +351,6 @@ protected:
             .setDirection(DirectionEnumT::CONST_IN)
             .addGbpRuleToClassifierRSrc(classifier4->getURI().toString())
             ->setTargetL24Classifier(classifier4->getURI());
-        con3->addGbpSubject("3_subject1")->addGbpRule("3_1_rule3")
-            ->setOrder(3)
-            .setDirection(DirectionEnumT::CONST_IN)
-            .addGbpRuleToClassifierRSrc(classifier10->getURI().toString())
-            ->setTargetL24Classifier(classifier10->getURI());
         epg0->addGbpEpGroupToProvContractRSrc(con3->getURI().toString());
         epg1->addGbpEpGroupToConsContractRSrc(con3->getURI().toString());
 

--- a/agent-ovs/ovs/AccessFlowManager.cpp
+++ b/agent-ovs/ovs/AccessFlowManager.cpp
@@ -136,7 +136,12 @@ static void flowBypassDhcpRequest(FlowEntryList& el, bool v4, uint32_t inport,
                                   uint32_t outport,
                                   std::shared_ptr<const Endpoint>& ep ) {
     FlowBuilder fb;
-    fb.priority(200).inPort(inport);
+    if (ep->getAccessIfaceVlan()) {
+        fb.priority(201).inPort(inport);
+    } else {
+        fb.priority(200).inPort(inport);
+    }
+
     flowutils::match_dhcp_req(fb, v4);
     fb.action().reg(MFF_REG7, outport);
 

--- a/agent-ovs/ovs/FlowUtils.cpp
+++ b/agent-ovs/ovs/FlowUtils.cpp
@@ -130,18 +130,8 @@ void add_classifier_entries(L24Classifier& clsfr, ClassAction act,
     ovs_be64 ckbe = ovs_htonll(cookie);
     MaskList srcPorts;
     MaskList dstPorts;
-    if (clsfr.getProt(0) == 1 &&
-        (clsfr.isIcmpTypeSet() || clsfr.isIcmpCodeSet())) {
-        if (clsfr.isIcmpTypeSet()) {
-            srcPorts.push_back(Mask(clsfr.getIcmpType(0), ~0));
-        }
-        if (clsfr.isIcmpCodeSet()) {
-            dstPorts.push_back(Mask(clsfr.getIcmpCode(0), ~0));
-        }
-    } else {
-        RangeMask::getMasks(clsfr.getSFromPort(), clsfr.getSToPort(), srcPorts);
-        RangeMask::getMasks(clsfr.getDFromPort(), clsfr.getDToPort(), dstPorts);
-    }
+    RangeMask::getMasks(clsfr.getSFromPort(), clsfr.getSToPort(), srcPorts);
+    RangeMask::getMasks(clsfr.getDFromPort(), clsfr.getDToPort(), dstPorts);
 
     /* Add a "ignore" mask to empty ranges - makes the loop later easy */
     if (srcPorts.empty()) {

--- a/agent-ovs/ovs/IntFlowManager.cpp
+++ b/agent-ovs/ovs/IntFlowManager.cpp
@@ -602,7 +602,8 @@ static void flowsProxyDiscovery(FlowEntryList& el,
                                 const uint8_t* matchSourceMac,
                                 uint32_t tunPort,
                                 IntFlowManager::EncapType encapType,
-                                bool directDelivery = false) {
+                                bool directDelivery = false,
+                                uint32_t dropInPort = OFPP_NONE) {
     if (ipAddr.is_v4()) {
         if (tunPort != OFPP_NONE &&
             encapType != IntFlowManager::ENCAP_NONE) {
@@ -617,11 +618,22 @@ static void flowsProxyDiscovery(FlowEntryList& el,
         }
         {
             FlowBuilder proxyArp;
+            // Match on inPort to ignore this arp (prio + 1)
+            if (dropInPort != OFPP_NONE)
+                proxyArp.priority(priority+1).inPort(dropInPort);
+            else
+                proxyArp.priority(priority);
+
             if (matchSourceMac)
                 proxyArp.ethSrc(matchSourceMac);
-            matchDestArp(proxyArp.priority(priority), ipAddr, bdId, rdId);
-            actionArpReply(proxyArp, macAddr, ipAddr)
-                .build(el);
+            matchDestArp(proxyArp, ipAddr, bdId, rdId);
+
+            // Drop the arp request on this inPort
+            if (dropInPort != OFPP_NONE)
+                proxyArp.build(el);
+            else
+                actionArpReply(proxyArp, macAddr, ipAddr)
+                    .build(el);
         }
     } else {
         // pass MAC address in flow metadata
@@ -929,6 +941,13 @@ static void flowsEndpointDHCPSource(IntFlowManager& flowMgr,
                            sizeof(serverMac));
                 }
 
+                // Ignore arp requests on uplink interface.
+                flowsProxyDiscovery(elBridgeDst, 51,
+                                    serverIp, serverMac,
+                                    epgVnid, rdId, bdId, false,
+                                    NULL, OFPP_NONE,
+                                    IntFlowManager::ENCAP_NONE,
+                                    false, flowMgr.getTunnelPort());
                 flowsProxyDiscovery(elBridgeDst, 51,
                                     serverIp, serverMac,
                                     epgVnid, rdId, bdId, false,

--- a/agent-ovs/ovs/test/AccessFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/AccessFlowManager_test.cpp
@@ -338,7 +338,7 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
     initExpEp(ep);
     if (ep->getDHCPv4Config()) {
         ADDF(Bldr()
-             .table(GRP).priority(200).udp().in(access)
+             .table(GRP).priority(ep->getAccessIfaceVlan() ? 201 : 200).udp().in(access)
              .isVlan(ep->getAccessIfaceVlan().get())
              .isTpSrc(68).isTpDst(67)
              .actions()
@@ -348,7 +348,7 @@ void AccessFlowManagerFixture::initExpDhcpEp(shared_ptr<Endpoint>& ep) {
     }
     if (ep->getDHCPv6Config()) {
         ADDF(Bldr()
-             .table(GRP).priority(200).udp6().in(access)
+             .table(GRP).priority(ep->getAccessIfaceVlan() ? 201 : 200).udp6().in(access)
              .isVlan(ep->getAccessIfaceVlan().get())
              .isTpSrc(546).isTpDst(547)
              .actions()

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -2895,6 +2895,7 @@ void BaseIntFlowManagerFixture::initExpVirtualDhcp(bool virtIp,
                                                    bool serverOverride) {
     string mmac("01:00:00:00:00:00/01:00:00:00:00:00");
     string bmac("ff:ff:ff:ff:ff:ff");
+    uint32_t tunPort = intFlowManager.getTunnelPort();
 
     uint32_t port = portmapper.FindPort(ep0->getInterfaceName().get());
     ADDF(Bldr().cookie(ovs_ntohll(flow::cookie::DHCP_V4))
@@ -2910,6 +2911,13 @@ void BaseIntFlowManagerFixture::initExpVirtualDhcp(bool virtIp,
         hexServerIp = "0x1020304";
         serverMac = "0xffbbffddeeff";
     }
+    ADDF(Bldr().table(BR).priority(52).arp()
+         .reg(BD, 1)
+         .reg(RD, 1)
+         .in(tunPort)
+         .isEthDst(bmac).isTpa(serverIp)
+         .isArpOp(1)
+         .actions().drop().done());
     ADDF(Bldr().table(BR).priority(51).arp()
          .reg(BD, 1)
          .reg(RD, 1)

--- a/agent-ovs/ovs/test/IntFlowManager_test.cpp
+++ b/agent-ovs/ovs/test/IntFlowManager_test.cpp
@@ -815,7 +815,7 @@ BOOST_FIXTURE_TEST_CASE(policy_portrange, VxlanIntFlowManagerFixture) {
     WAIT_FOR_DO(egs.size() == 1, 500, egs.clear();
                 policyMgr.getContractConsumers(con3->getURI(), egs));
     PolicyManager::rule_list_t rules;
-    WAIT_FOR_DO(rules.size() == 3, 500, rules.clear();
+    WAIT_FOR_DO(rules.size() == 2, 500, rules.clear();
                 policyMgr.getContractRules(con3->getURI(), rules));
 
     /* add con3 */
@@ -2188,9 +2188,6 @@ void BaseIntFlowManagerFixture::initExpCon3() {
     const opflex::modb::URI& ruleURI_4 = classifier4.get()->getURI();
     uint32_t con4_cookie = intFlowManager.getId(
                          classifier4->getClassId(), ruleURI_4);
-    const opflex::modb::URI& ruleURI_10 = classifier10.get()->getURI();
-    uint32_t con10_cookie = intFlowManager.getId(
-        classifier10->getClassId(), ruleURI_10);
     MaskList ml_80_85 = list_of<Mask>(0x0050, 0xfffc)(0x0054, 0xfffe);
     MaskList ml_66_69 = list_of<Mask>(0x0042, 0xfffe)(0x0044, 0xfffe);
     MaskList ml_94_95 = list_of<Mask>(0x005e, 0xfffe);
@@ -2209,9 +2206,6 @@ void BaseIntFlowManagerFixture::initExpCon3() {
                  .actions().go(OUT).done());
         }
     }
-    ADDF(Bldr(SEND_FLOW_REM).table(POL).priority(prio-256)
-        .cookie(con10_cookie).icmp().reg(SEPG, epg1_vnid).reg(DEPG, epg0_vnid)
-        .icmp_type(10).icmp_code(5).actions().go(OUT).done());
 }
 
 // Initialize flows related to IP address mapping/NAT

--- a/agent-ovs/rpm/opflex-agent.spec.in
+++ b/agent-ovs/rpm/opflex-agent.spec.in
@@ -20,21 +20,26 @@ Group: System Environment/Daemons
 License: EPLv1.0
 URL: https://wiki.opendaylight.org/view/OpFlex:Main
 
+# Add --without dynboost option. Enable by default
+%bcond_without dynboost
+
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
 Source: %{name}-%{version}.tar.gz
 Requires: libopflex >= %{version}
 Requires: libmodelgbp >= %{version}
 Requires: opflex-agent-lib = %{epoch}:%{version}-%{release}
+%if %{with dynboost}
 Requires: boost >= 1.53
 Requires: boost-program-options
 Requires: boost-system
 Requires: boost-date-time
 Requires: boost-thread
 Requires: boost-filesystem
-BuildRequires: libopflex-devel
-BuildRequires: libmodelgbp-devel
 BuildRequires: boost-devel
 BuildRequires: boost-test
+%endif
+BuildRequires: libopflex-devel
+BuildRequires: libmodelgbp-devel
 BuildRequires: noiro-openvswitch-devel >= 2.6.0
 BuildRequires: noiro-openvswitch-lib >= 2.6.0
 BuildRequires: doxygen
@@ -106,7 +111,11 @@ Development libraries for libopflex_agent
 %setup -q
 
 %build
+%if %{with dynboost}
 %configure --disable-assert
+%else
+%configure --disable-assert --with-static-boost --with-boost=/usr/local/boost_1_58_0
+%endif
 make %{?_smp_mflags}
 
 %install

--- a/agent-ovs/rpm/opflex-agent.spec.in
+++ b/agent-ovs/rpm/opflex-agent.spec.in
@@ -168,6 +168,7 @@ getent group opflexep >/dev/null || groupadd -r opflexep
         /bin/systemctl daemon-reload >dev/null || :
     fi
 %endif
+/bin/pkill -9 agent-ovs || :
 
 %post renderer-openvswitch
 /bin/systemctl daemon-reload >dev/null || :

--- a/agent-ovs/rpm/opflex-agent.spec.in
+++ b/agent-ovs/rpm/opflex-agent.spec.in
@@ -125,8 +125,8 @@ install -p -D -m 0644 \
     $RPM_BUILD_ROOT%{_sysctldir}/90-opflex-agent-sysctl.conf
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/opflex-agent-ovs/endpoints
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/opflex-agent-ovs/services
+mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/opflex-agent-ovs/ids
 mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/opflex-agent-ovs/mcast
-mkdir -p $RPM_BUILD_ROOT%{_localstatedir}/lib/opflex-agent-ovs/openvswitch/ids
 mkdir -p $RPM_BUILD_ROOT%{_sysconfdir}/opflex-agent-ovs/conf.d
 
 %check
@@ -202,6 +202,7 @@ getent group opflexep >/dev/null || groupadd -r opflexep
 %dir %attr(0775, root, opflexep) %{_localstatedir}/lib/opflex-agent-ovs/endpoints
 %dir %attr(0775, root, opflexep) %{_localstatedir}/lib/opflex-agent-ovs/services
 %dir %{_localstatedir}/lib/opflex-agent-ovs/mcast
+%dir %{_localstatedir}/lib/opflex-agent-ovs/ids
 
 %files -n agent-ovs
 
@@ -209,7 +210,6 @@ getent group opflexep >/dev/null || groupadd -r opflexep
 %defattr(-,root,root)
 %{_libdir}/libopflex_agent_renderer_openvswitch.so*
 %config(noreplace) %{_sysconfdir}/opflex-agent-ovs/plugins.conf.d/plugin-renderer-openvswitch.conf
-%dir %{_localstatedir}/lib/opflex-agent-ovs/openvswitch/ids
 %{_unitdir}/opflex-agent.service.d/10-opflex-agent-openvswitch.conf
 
 %files lib

--- a/libopflex/configure.ac
+++ b/libopflex/configure.ac
@@ -74,6 +74,27 @@ AC_ARG_WITH(buildversion,
             [sdk_bversion=${withval}],
             [sdk_bversion='private'])
 
+# --with-static-boost enables linking with a static boost library
+# Disabled by default
+# --with-static-boost also requires --with-boost that points to
+# boost location with boost static libraries compiled with -fPIC
+# option to enable linking them with shared libraries.
+AC_ARG_WITH([static-boost],
+            [AS_HELP_STRING([--with-static-boost],[Enable static boost support])],
+            [],[with_static_boost=no])
+AS_IF([test "x$with_static_boost" != xno], [
+      AC_ARG_WITH([boost],
+                  [AS_HELP_STRING([--with-boost],[Use boost from location])],
+                  [], [AC_MSG_FAILURE([--with-static-boost given, but --with-boost is missing])])
+])
+AM_CONDITIONAL([HAVE_STATIC_BOOST],[test "x$with_static_boost" != 'xno'])
+if test "x$with_static_boost" != xno; then
+   AC_SUBST(BOOST_STATIC_LIB_DIR, [$with_boost])
+   AC_MSG_NOTICE([Building with Static boost libraries from $with_boost])
+else
+   AC_MSG_NOTICE([Building without Static boost libraries])
+fi
+
 dnl allow to create final builds with assert()s disabled
 AC_HEADER_ASSERT
 

--- a/libopflex/rpm/libopflex.spec.in
+++ b/libopflex/rpm/libopflex.spec.in
@@ -20,14 +20,19 @@ Group: Development/Libraries
 License: EPLv1.0
 URL: https://wiki.opendaylight.org/view/OpFlex:Main
 
+# Add --without dynboost option. Enable by default
+%bcond_without dynboost
+
 BuildRoot: %{_tmppath}/%{name}-%{version}-root
 Source: %{name}-%{version}.tar.gz
 Requires: libuv >= 1.0
 Requires: openssl >= 1.0.1
 BuildRequires: libuv-devel
 BuildRequires: openssl-devel
+%if %{with dynboost}
 BuildRequires: boost-devel
 BuildRequires: boost-test
+%endif
 BuildRequires: rapidjson-devel >= 1.0
 BuildRequires: doxygen
 BuildRequires: pkgconfig
@@ -57,7 +62,11 @@ Development libraries for libopflex
 %setup -q
 
 %build
+%if %{with dynboost}
 %configure --disable-assert --disable-tests-make-all
+%else
+%configure --disable-assert --with-static-boost --with-boost=/usr/local/boost_1_58_0
+%endif
 make %{?_smp_mflags}
 
 %install


### PR DESCRIPTION
agent-ovs is compiled and tested with 1.58 version of boost.

Some redhat distros do not have this older version of boost,
and installing agent-ovs rpm on such systems can cause issues.

So we link the boost libraries statically and eliminate this
dependency.

Since this involves linking against other shared libraries, it
requires that libboost*.a objects be compiled with -fPIC option.

This can be done on any build system once and copied to
/usr/local/boost_1_58_0 that the static rpm file uses.

    wget http://sourceforge.net/projects/boost/files/boost/1.58.0/boost_1_58_0.tar.gz
    tar zxvf boost_1_58_0.tar.gz
    cd boost_1_58_0/
    ./bootstrap.sh --prefix=/usr/local/boost_1_58_0
    ./b2 cxxflags=-fPIC cflags=-fPIC -a
    ./b2 install --prefix=/usr/local/boost_1_58_0

The agent and libopflex code is built as follows.

    ./autogen.sh
    ./configure --enable-boost-static --with-boost=/usr/local/boost_1_58_0

This would include the .a(s) inside the artifcats.

Note that this option is *DISABLED* by default. So if not specified it should
not affect existing builds.

Signed-off-by: Madhu Challa <challa@gmail.com>